### PR TITLE
Fix HTML entity escaping issue

### DIFF
--- a/mcp-a2a-security.html
+++ b/mcp-a2a-security.html
@@ -341,7 +341,7 @@
                         <div class="flex justify-center"><span class="diagram-arrow text-2xl">&darr;</span></div>
                         <div class="diagram-box">2. Identify Assets, Trust Boundaries, Data Flows</div>
                         <div class="flex justify-center"><span class="diagram-arrow text-2xl">&darr;</span></div>
-                        <div class="diagram-box">3. Threat Enumeration (STRIDE, MAESTRO, ATT&CK for AI)</div>
+                        <div class="diagram-box">3. Threat Enumeration (STRIDE, MAESTRO, ATT&amp;CK for AI)</div>
                         <div class="flex justify-center"><span class="diagram-arrow text-2xl">&darr;</span></div>
                         <div class="diagram-box">4. Analyze Vulnerabilities</div>
                         <div class="flex justify-center"><span class="diagram-arrow text-2xl">&darr;</span></div>


### PR DESCRIPTION
## Summary
- escape ampersand in threat modeling workflow so HTML validates

## Testing
- `tidy -errors -q mcp-a2a-security.html`

------
https://chatgpt.com/codex/tasks/task_e_6840d418c4148321a61ac2a3f2882031